### PR TITLE
Scalar and return type declarations + more

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,8 @@
         "php" : ">=7.0.11"
     },
     "require-dev": {
-        "phpunit/phpunit" : "4.*",
-	"phpdocumentor/phpdocumentor" : "2.*"
+        "phpunit/phpunit": "~5.0",
+        "phpdocumentor/phpdocumentor" : "2.*"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
- Added scalar & return type declarations. See: http://php.net/manual/en/migration70.new-features.php
- ~~Made a beginning with property and method tags (https://github.com/jcupitt/php-vips/issues/8).~~ writing them by hand is hard and time inefficient.
- Fixed some issues with `array_merge` (https://github.com/jcupitt/php-vips/issues/11).
- Fixed return and scalar PHPDoc values (long -> int, double -> float, mixed[] -> array). And edited some to the right ones.
- Updated PHPUnit.
- Corrected some typos.
- phpcs indenting fixes.

TODO:
- Add unit tests for edited functions which are not tested yet (although it's passing now: `OK (27 tests, 64 assertions)`).
- Add **automatic** all the property and method PHPDoc tags.
- Add **automatic** constants for common string types (`VIPS_INTERPRETATION`, `VIPS_ANGLE` etc.).