### PR TITLE
Improved logging, enumerations and more

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "php" : ">=7.0.11",
-	"ext-vips" : ">=0.1.0"
+	"ext-vips" : ">=0.1.1"
     },
     "require-dev": {
         "phpunit/phpunit": "~5.0",

--- a/composer.json
+++ b/composer.json
@@ -17,12 +17,14 @@
         }
     ],
     "require": {
-        "php" : ">=7.0.11",
-	"ext-vips" : ">=0.1.1"
+        "php": ">=7.0.11",
+        "ext-vips": ">=0.1.1",
+        "psr/log": "^1.0.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "~5.0",
-        "phpdocumentor/phpdocumentor" : "2.*"
+        "phpunit/phpunit": "^5.5",
+        "phpdocumentor/phpdocumentor" : "2.*",
+        "jakub-onderka/php-parallel-lint": "^0.9"
     },
     "autoload": {
         "psr-4": {
@@ -34,9 +36,18 @@
             "Jcupitt\\Vips\\Test\\": "tests"
         }
     },
+    "provide": {
+        "psr/log-implementation": "1.0.0"
+    },
     "extra": {
         "branch-alias": {
             "dev-master": "1.0-dev"
         }
+    },
+    "scripts": {
+        "test": [
+            "parallel-lint . --exclude vendor",
+            "phpunit"
+        ]
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "2d3ea0e463980902567dbb1ae386faad",
-    "content-hash": "4dee974fa6b968910996ae13141ff4c6",
+    "hash": "45522e2e4c88f2fffceb0b6b6829e7a0",
+    "content-hash": "5f6cd0691a0b8d3621935b15d1f7905e",
     "packages": [],
     "packages-dev": [
         {
@@ -3825,7 +3825,7 @@
     "prefer-lowest": false,
     "platform": {
         "php": ">=7.0.11",
-        "ext-vips": ">=0.1.0"
+        "ext-vips": ">=0.1.1"
     },
     "platform-dev": []
 }

--- a/examples/vips_addconst.php
+++ b/examples/vips_addconst.php
@@ -1,11 +1,9 @@
 #!/usr/bin/env php
-<?php 
+<?php
 
-include '../src/Image.php';
+require __DIR__ . '/../vendor/autoload.php';
 
 use Jcupitt\Vips;
 
 $image = Vips\Image::newFromArray([[1, 2, 3], [4, 5, 6]]);
 $image = $image->linear(1, 1);
-
-?>

--- a/examples/vips_bench.php
+++ b/examples/vips_bench.php
@@ -1,22 +1,21 @@
 #!/usr/bin/env php
 <?php
 
-include '../src/Image.php';
+require __DIR__ . '/../vendor/autoload.php';
 
 use Jcupitt\Vips;
 
-$im = Vips\Image::newFromFile($argv[1], ["access" => "sequential"]);
+$im = Vips\Image::newFromFile($argv[1], ["access" => Vips\Enum\Access::SEQUENTIAL]);
 
 $im = $im->crop(100, 100, $im->width - 200, $im->height - 200);
 
-$im = $im->reduce(1.0 / 0.9, 1.0 / 0.9, ["kernel" => "linear"]);
+$im = $im->reduce(1.0 / 0.9, 1.0 / 0.9, ["kernel" => Vips\Enum\Kernel::LINEAR]);
 
-$mask = Vips\Image::newFromArray(
-		  [[-1,  -1, -1], 
-		   [-1,  16, -1], 
-		   [-1,  -1, -1]], 8);
+$mask = Vips\Image::newFromArray([
+    [-1,  -1, -1],
+    [-1,  16, -1],
+    [-1,  -1, -1]
+], 8);
 $im = $im->conv($mask);
 
 $im->writeToFile($argv[2]);
-
-?>

--- a/examples/vips_class.php
+++ b/examples/vips_class.php
@@ -1,18 +1,63 @@
 #!/usr/bin/env php
 <?php
 
-include '../src/Image.php';
+require __DIR__ . '/../vendor/autoload.php';
 
 use Jcupitt\Vips;
 
-Vips\Image::setLogging(true);
+const LOG_FORMAT = "[%datetime%] %level_name%: %message% %context%\n";
+const DATE_FORMAT = "Y-m-d\TH:i:sP";
 
-$image = Vips\Image::newFromFile($argv[1]); 
+Vips\Image::setLogger(new class implements Psr\Log\LoggerInterface {
+    // Use the LoggerTait so that we only have to implement the generic log method.
+    use Psr\Log\LoggerTrait;
 
-echo "width = ", $image->width, "\n";
+    /**
+     * Logs with an arbitrary level.
+     *
+     * @param mixed  $level
+     * @param string $message
+     * @param array  $context
+     *
+     * @return void
+     */
+    public function log($level, $message, array $context = [])
+    {
+        // `Vips\Image` to string convert
+        array_walk_recursive($context, function (&$value) {
+            if ($value instanceof Vips\Image) {
+                // TODO: Should we override __toString() in `Vips\Image` instead
+                $value = [
+                    'instance' => 'Vips\Image',
+                    'width' => $value->width,
+                    'height' => $value->height,
+                    'bands' => $value->bands,
+                    'format' => $value->format,
+                    'interpretation' =>  $value->interpretation,
+                ];
+            }
+        });
+
+        $strParams = [
+            '%datetime%' => date(DATE_FORMAT),
+            '%level_name%' => $level,
+            '%message%' => $message,
+            '%context%' => json_encode(
+                $context,
+                JSON_UNESCAPED_SLASHES |
+                JSON_UNESCAPED_UNICODE |
+                JSON_PRESERVE_ZERO_FRACTION
+            ),
+        ];
+
+        echo strtr(LOG_FORMAT, $strParams);
+    }
+});
+
+$image = Vips\Image::newFromFile($argv[1]);
+
+echo "width = " . $image->width . "\n";
 
 $image = $image->invert();
 
 $image->writeToFile($argv[2]);
-
-?>

--- a/src/Main.php
+++ b/src/Main.php
@@ -53,7 +53,7 @@ namespace Jcupitt\Vips;
 class Main
 {
     /**
-     * Set the maximum number of operations to hold in the libvips operation 
+     * Set the maximum number of operations to hold in the libvips operation
      * cache.
      *
      * @param integer $value The maximum number of operations to cache.
@@ -70,7 +70,7 @@ class Main
      * bytes.
      *
      * @param integer $value The maximum amount of memory cached opertations can
-     *     hold, in bytes. 
+     *     hold, in bytes.
      *
      * @return void
      */
@@ -82,7 +82,7 @@ class Main
     /**
      * Set the maximum number of open files cached operations can use.
      *
-     * @param integer $value The maximum number of open files cached operations 
+     * @param integer $value The maximum number of open files cached operations
      *      can use.
      *
      * @return void
@@ -93,10 +93,10 @@ class Main
     }
 
     /**
-     * Set the size of the pools of worker threads vips uses for image 
-     * evaluation. 
+     * Set the size of the pools of worker threads vips uses for image
+     * evaluation.
      *
-     * @param integer $value The size of the pools of worker threads vips uses 
+     * @param integer $value The size of the pools of worker threads vips uses
      *      for image evaluation.
      *
      * @return void
@@ -105,7 +105,6 @@ class Main
     {
         vips_concurrency_set($value);
     }
-
 }
 
 /*

--- a/tests/call.php
+++ b/tests/call.php
@@ -7,7 +7,7 @@ class VipsCallTest extends PHPUnit_Framework_TestCase
     public function testVipsCall()
     {
         $image = Vips\Image::newFromArray([1, 2, 3]);
-        $image = $image->embed(10, 20, 3000, 2000, ["extend" => "copy"]);
+        $image = $image->embed(10, 20, 3000, 2000, ["extend" => Vips\Enum\Extend::COPY]);
 
         $this->assertEquals($image->width, 3000);
         $this->assertEquals($image->height, 2000);

--- a/tests/logger.php
+++ b/tests/logger.php
@@ -1,0 +1,42 @@
+<?php
+
+use Jcupitt\Vips;
+
+class VipsLoggerTest extends PHPUnit_Framework_TestCase
+{
+    public function testGetLoggerCall()
+    {
+        // Asserts that getLogger without setting it should
+        // return a null value.
+        $logger = Vips\Image::getLogger();
+
+        $this->assertNull($logger);
+    }
+
+    public function testSetLoggerCall()
+    {
+        Vips\Image::setLogger(new class implements Psr\Log\LoggerInterface {
+            use Psr\Log\LoggerTrait;
+
+            public function log($level, $message, array $context = array())
+            {
+                // Do logging logic here.
+            }
+        });
+
+        $logger = Vips\Image::getLogger();
+
+        // Asserts that getLogger should return an instance of Psr\Log\LoggerInterface
+        $this->assertInstanceOf(Psr\Log\LoggerInterface::class, $logger);
+    }
+
+}
+
+/*
+ * Local variables:
+ * tab-width: 4
+ * c-basic-offset: 4
+ * End:
+ * vim600: expandtab sw=4 ts=4 fdm=marker
+ * vim<600: expandtab sw=4 ts=4
+ */


### PR DESCRIPTION
### What have we got here?
- Allow the users to define there own logging logic; with `setLogger` and `getLogger`. Following the `PSR-3 Logger Interface` standards.
- Added a example how to use `setLogger`. See `examples\vips_class.php`.
- `include '../src/Image.php';` didn't work in the examples. I've changed it to `require __DIR__ . '/../vendor/autoload.php';` for auto-loading.
- Updated `phpunit` in `composer.json`.
- Added a require for `"psr/log": "^1.0.1"` in `composer.json` to ensure that the PSR-3 interface and trait is included.
- Added [`PHP Parallel Lint`](https://github.com/JakubOnderka/PHP-Parallel-Lint) to check syntax of PHP files in parallel jobs.
- Added a script to test the syntax of PHP files and unit tests. Usage: `composer test` (see output below).
- phpcs indenting fixes. Fixes all `Whitespace found at end of line` errors.
- Use the enumerations instead of the hard-coded strings.
- `Property names SHOULD NOT be prefixed with a single underscore to indicate protected or private visibility.` following the `PSR-2: Coding Style Guide`. So I've removed those underscores.
- After changing the underscores `wrap` was conflicting with the `wrap` function in libvips. I changed to `wrapResult` instead.
- Added unit tests for the improved logging. (2 simple tests).

### Example outputs:
`php vips_class.php test.jpg test2.jpg`

Outputs:
```sh
width = 1967
[2016-10-20T19:33:26+02:00] debug: Called 'callBase' {"name":"invert","instance":{"instance":"Vips\\Image","width":1967,"height":2421,"bands":3,"format":"uchar","interpretation":"srgb"},"arguments":[]}
[2016-10-20T19:33:26+02:00] debug: Result 'callBase' {"name":"invert","result":{"instance":"Vips\\Image","width":1967,"height":2421,"bands":3,"format":"uchar","interpretation":"srgb"}}
```

`composer test`

Outputs:
```sh
> parallel-lint . --exclude vendor
PHP 7.0.12 | 10 parallel jobs
...................................................          51/51 (100 %)


Checked 51 files in 0.3 seconds
No syntax error found
> phpunit
PHPUnit 5.6.1 by Sebastian Bergmann and contributors.

................................................                  48 / 48 (100%)

Time: 4.5 seconds, Memory: 6.00MB

OK (48 tests, 89 assertions)
```