### PR TITLE
Travis CI integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: php
 
-sudo: false
+sudo: required
 dist: trusty
 
 php:
@@ -8,9 +8,7 @@ php:
   - 7.1
 
 env:
-  - LIBVIPS=8.3
-  - LIBVIPS=8.4
-  - LIBVIPS=master
+  - LIBVIPS=8.4.4
 
 cache:
   apt: true
@@ -21,7 +19,6 @@ addons:
   apt:
     packages:
       - gobject-introspection
-      - gtk-doc-tools
       - libcfitsio3-dev
       - libfftw3-dev
       - libgif-dev
@@ -36,10 +33,9 @@ addons:
 
 # VIPS 8.3.3 requires Poppler 0.30 which is not released on Trusty.
 before_install:
-  - wget https://github.com/jcupitt/libvips/archive/$LIBVIPS.zip
-  - unzip $LIBVIPS
-  - cd libvips-$LIBVIPS
-  - test -f autogen.sh && ./autogen.sh || ./bootstrap.sh
+  - wget http://www.vips.ecs.soton.ac.uk/supported/current/vips-$LIBVIPS.tar.gz
+  - tar -xvzf vips-$LIBVIPS.tar.gz
+  - cd vips-$LIBVIPS
   - >
     CXXFLAGS=-D_GLIBCXX_USE_CXX11_ABI=0
     ./configure
@@ -54,8 +50,8 @@ before_install:
     --without-python
     $1
   - make
-  - make install
-  - ldconfig
+  - sudo make install
+  - sudo ldconfig
   - cd ..
   - yes '' | pecl install vips
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: php
 
-sudo: required
+sudo: false
 dist: trusty
 
 php:
@@ -54,8 +54,8 @@ before_install:
     --without-python
     $1
   - make
-  - sudo make install
-  - sudo ldconfig
+  - make install
+  - ldconfig
   - cd ..
   - yes '' | pecl install vips
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,64 @@
 language: php
-         
+
+sudo: required
+dist: trusty
+
 php:
-  - 7.0
+  - 7.0.13
+  - 7.1
 
-before_script:
-  - composer self-update
-  - composer install --prefer-source --no-interaction --dev
+env:
+  - LIBVIPS=8.3
+  - LIBVIPS=8.4
+  - LIBVIPS=master
 
-script: phpunit
+cache:
+  apt: true
+  directories:
+    - $HOME/.composer/cache
+
+addons:
+  apt:
+    packages:
+      - gobject-introspection
+      - gtk-doc-tools
+      - libcfitsio3-dev
+      - libfftw3-dev
+      - libgif-dev
+      - libgs-dev
+      - libgsf-1-dev
+      - libmatio-dev
+      - libopenslide-dev
+      - liborc-0.4-dev
+      - libpango1.0-dev
+      - libpoppler-glib-dev
+      - libwebp-dev
+
+# VIPS 8.3.3 requires Poppler 0.30 which is not released on Trusty.
+before_install:
+  - wget https://github.com/jcupitt/libvips/archive/$LIBVIPS.zip
+  - unzip $LIBVIPS
+  - cd libvips-$LIBVIPS
+  - test -f autogen.sh && ./autogen.sh || ./bootstrap.sh
+  - >
+    CXXFLAGS=-D_GLIBCXX_USE_CXX11_ABI=0
+    ./configure
+    --disable-debug
+    --disable-dependency-tracking
+    --disable-introspection
+    --disable-static
+    --enable-gtk-doc-html=no
+    --enable-gtk-doc=no
+    --enable-pyvips8=no
+    --without-orc
+    --without-python
+    $1
+  - make
+  - sudo make install
+  - sudo ldconfig
+  - cd ..
+  - yes '' | pecl install vips
+
+install: composer install --prefer-dist
+
+script: composer test


### PR DESCRIPTION
You can see the output of the Travis CI build(s) here: https://travis-ci.org/kleisauke/php-vips/builds/178825558

It's failing on PHP 7.1 because of this:
```bash
1) VipsConvenienceTest::testVipsMaxpos
Failed asserting that two arrays are equal.
--- Expected
+++ Actual
@@ @@
 Array (
-    0 => null
-    1 => null
-    2 => null
+    0 => 6
+    1 => 2
+    2 => 1
 )
 
/home/travis/build/kleisauke/php-vips/tests/convenience.php:123
```

I'm not sure why that test is failing. At first look I could not find any fault in that test case.