### PR TITLE
General improvements

### DIFF
--- a/src/Image.php
+++ b/src/Image.php
@@ -1154,7 +1154,7 @@ class Image extends ImageAutodoc implements \ArrayAccess
 
         $arguments = array_merge([$name, $instance], $arguments);
 
-        $arguments = self::unwrap($arguments);
+        $arguments = array_values(self::unwrap($arguments));
         $result = vips_call(...$arguments);
         self::errorIsArray($result);
         $result = self::wrapResult($result);


### PR DESCRIPTION
General improvements:
- Remove not needed 'else' statements (because of the last statement in if-branch).
- Add missing `@throws` tag at the `offsetSet` and `offsetUnset` functions.
- Switch to `$this` for non-static members.
- Add `_isset` magic method to check if the GType of a property from the underlying image exists. For example:
	```php
	<?php

	use Jcupitt\Vips;

	$image = Vips\Image::newFromFile('Landscape_6.jpg', ['access' => Vips\Access::SEQUENTIAL]);

	# Check if it has a orientation tag
	if(isset($image->orientation)) {
	    # Output the int from 1 - 8 using the standard exif/tiff meanings
	    echo $image->orientation;
	}
	```
- Use more strict `===` were possible.
- Replace class reference `Image` by `self`.
- Declare `: Image` as return type hint at the `newFromImage` and `copyMemory` function.
- Use `vips_call(...$arguments)` instead (3x+ faster). See: http://php.net/manual/en/function.call-user-func-array.php#117655
- Remove PHPDoc for non-existing argument at the `hasAlpha` function.
- Switch from `is_null` to `=== null`.