### PR TITLE
Enable phpcs for Travis + more

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
   global:
     - VIPS_VERSION_MAJOR=8
     - VIPS_VERSION_MINOR=5
-    - VIPS_VERSION_MICRO=3
+    - VIPS_VERSION_MICRO=8
     - PATH=$HOME/vips/bin:$PATH
     - LD_LIBRARY_PATH=$HOME/vips/lib:$LD_LIBRARY_PATH
     - PKG_CONFIG_PATH=$HOME/vips/lib/pkgconfig:$PKG_CONFIG_PATH

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
     "require-dev": {
         "phpunit/phpunit": "^6.0",
         "phpdocumentor/phpdocumentor" : "^2.9",
-        "jakub-onderka/php-parallel-lint": "^0.9.2"
+        "jakub-onderka/php-parallel-lint": "^0.9.2",
+        "squizlabs/php_codesniffer": "3.*"
     },
     "autoload": {
         "psr-4": {
@@ -44,7 +45,8 @@
     "scripts": {
         "test": [
             "parallel-lint . --exclude vendor",
-            "phpunit"
+            "phpunit",
+            "phpcs -p --standard=PSR2 --extensions=php --ignore=/vendor/ ."
         ]
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "psr/log": "^1.0.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.0",
+        "phpunit/phpunit": "^6.3",
         "phpdocumentor/phpdocumentor" : "^2.9",
         "jakub-onderka/php-parallel-lint": "^0.9.2",
         "squizlabs/php_codesniffer": "3.*"

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
         "test": [
             "parallel-lint . --exclude vendor",
             "phpunit",
-            "phpcs -np --standard=PSR2 --extensions=php --ignore=/vendor/ ."
+            "phpcs --standard=phpcs-ruleset.xml ."
         ]
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
         "test": [
             "parallel-lint . --exclude vendor",
             "phpunit",
-            "phpcs -p --standard=PSR2 --extensions=php --ignore=/vendor/ ."
+            "phpcs -np --standard=PSR2 --extensions=php --ignore=/vendor/ ."
         ]
     }
 }

--- a/examples/class.php
+++ b/examples/class.php
@@ -9,7 +9,7 @@ Vips\Config::setLogger(new Vips\DebugLogger());
 
 $image = Vips\Image::newFromFile($argv[1]);
 
-echo "width = " . $image->width . "\n";
+echo 'width = ' . $image->width . "\n";
 
 $image = $image->invert();
 

--- a/examples/sig.php
+++ b/examples/sig.php
@@ -2,107 +2,153 @@
 <?php
 
 require __DIR__ . '/../vendor/autoload.php';
+
 use Jcupitt\Vips;
 
-# sigmoidal contrast adjustment in php-vips
-
-# This is a standard contrast adjustment technique: grey values are put through
-# an S-shaped curve which boosts the slope in the mid-tones and drops it for
-# white and black.
-
-function sigmoid(float $alpha, float $beta, bool $ushort = false): Vips\Image
+/**
+ * sigmoidal contrast adjustment in php-vips
+ *
+ * This is a standard contrast adjustment technique: grey values are put through
+ * an S-shaped curve which boosts the slope in the mid-tones and drops it for
+ * white and black.
+ *
+ * @param bool $sharpen If true increase the contrast, if false decrease the contrast.
+ * @param float $midpoint Midpoint of the contrast (typically 0.5).
+ * @param float $contrast Strength of the contrast (typically 3-20).
+ * @param bool $ushort Indicating if we have a 16-bit LUT.
+ *
+ * @return Vips\Image 16-bit or 8-bit LUT
+ */
+function sigmoid(bool $sharpen, float $midpoint, float $contrast, bool $ushort = false): Vips\Image
 {
-    # make a identity LUT, that is, a lut where each pixel has the value of
-    # its index ... if you map an image through the identity, you get the
-    # same image back again
-    #
-    # LUTs in libvips are just images with either the width or height set
-    # to 1, and the 'interpretation' tag set to HISTOGRAM
-    #
-    # if 'ushort' is TRUE, we make a 16-bit LUT, ie. 0 - 65535 values;
-    # otherwise it's 8-bit (0 - 255)
+    /**
+     * Make a identity LUT, that is, a lut where each pixel has the value of
+     * its index ... if you map an image through the identity, you get the
+     * same image back again.
+     *
+     * LUTs in libvips are just images with either the width or height set
+     * to 1, and the 'interpretation' tag set to HISTOGRAM.
+     *
+     * If 'ushort' is TRUE, we make a 16-bit LUT, ie. 0 - 65535 values;
+     * otherwise it's 8-bit (0 - 255)
+     */
     $lut = Vips\Image::identity(['ushort' => $ushort]);
 
-    # rescale so each element is in [0, 1]
-    $max = $lut->max();
-    $lut = $lut->divide($max);
+    // Rescale so each element is in [0, 1]
+    $range = $lut->max();
+    $lut = $lut->divide($range);
 
-    # the sigmoidal equation, see
-    #
-    # http://www.imagemagick.org/Usage/color_mods/#sigmoidal
-    #
-    # though that's missing a term -- it should be
-    #
-    # (1/(1+exp(β*(α-u))) - 1/(1+exp(β*α))) /
-    #   (1/(1+exp(β*(α-1))) - 1/(1+exp(β*α)))
-    #
-    # ie. there should be an extra α in the second term
-    $x = 1.0 / (1.0 + exp($beta * $alpha));
-    $y = 1.0 / (1.0 + exp($beta * ($alpha - 1.0))) - $x;
-    $z = $lut->multiply(-1)->add($alpha)->multiply($beta)->exp()->add(1);
-    $result = $z->pow(-1)->subtract($x)->divide($y);
+    /**
+     * The sigmoidal equation, see
+     *
+     * http://www.imagemagick.org/Usage/color_mods/#sigmoidal
+     *
+     * and
+     *
+     * http://osdir.com/ml/video.image-magick.devel/2005-04/msg00006.html
+     *
+     * Though that's missing a term -- it should be
+     *
+     * (1/(1+exp(β*(α-u))) - 1/(1+exp(β*α))) /
+     *   (1/(1+exp(β*(α-1))) - 1/(1+exp(β*α)))
+     *
+     * ie. there should be an extra α in the second term
+     */
+    if ($sharpen) {
+        $x = $lut->multiply(-1)->add($midpoint)->multiply($contrast)->exp()->add(1)->pow(-1);
+        $min = $x->min();
+        $max = $x->max();
+        $result = $x->subtract($min)->divide($max - $min);
+    } else {
+        $min = 1 / (1 + exp($contrast * $midpoint));
+        $max = 1 / (1 + exp($contrast * ($midpoint - 1)));
+        $x = $lut->multiply($max - $min)->add($min);
+        $result = $x->multiply(-1)->add(1)->divide($x)->log()->divide($contrast)->multiply(-1)->add($midpoint);
+    }
 
-    # rescale back to 0 - 255 or 0 - 65535
-    $result = $result->multiply($max);
+    // Rescale back to 0 - 255 or 0 - 65535
+    $result = $result->multiply($range);
 
-    # and get the format right ... $result will be a float image after all
-    # that maths, but we want uchar or ushort
-    $result = $result->cast($ushort ?
-        Vips\BandFormat::USHORT : Vips\BandFormat::UCHAR);
-
+    /**
+     * And get the format right ... $result will be a float image after all
+     * that maths, but we want uchar or ushort
+     */
+    $result = $result->cast($ushort ? Vips\BandFormat::USHORT : Vips\BandFormat::UCHAR);
     return $result;
 }
 
-# Apply to RGB. This takes no account of image gamma, and applies the 
-# contrast boost to R, G and B bands, thereby also boosting colourfulness. 
-function sigRGB(Vips\Image $image, float $alpha, float $beta): Vips\Image
+/**
+ * Apply to RGB. This takes no account of image gamma, and applies the
+ * contrast boost to R, G and B bands, thereby also boosting colourfulness.
+ *
+ * @param Vips\Image $image The source image.
+ * @param bool $sharpen If true increase the contrast, if false decrease the contrast.
+ * @param float $midpoint Midpoint of the contrast (typically 0.5).
+ * @param float $contrast Strength of the contrast (typically 3-20).
+ *
+ * @return Vips\Image The manipulated image.
+ */
+function sigRGB(Vips\Image $image, bool $sharpen, float $midpoint, float $contrast): Vips\Image
 {
-    $lut = sigmoid($alpha, $beta, $image->format == Vips\BandFormat::USHORT);
-
+    $lut = sigmoid($sharpen, $midpoint, $contrast, $image->format === Vips\BandFormat::USHORT);
     return $image->maplut($lut);
 }
 
-# Fancier: apply to L of CIELAB. This will change luminance equally, and will
-# not change colourfulness.
-function sigLAB(Vips\Image $image, float $alpha, float $beta): Vips\Image
+/**
+ * Fancier: apply to L of CIELAB. This will change luminance equally, and will
+ * not change colourfulness.
+ *
+ * @param Vips\Image $image The source image.
+ * @param bool $sharpen If true increase the contrast, if false decrease the contrast.
+ * @param float $midpoint Midpoint of the contrast (typically 0.5).
+ * @param float $contrast Strength of the contrast (typically 3-20).
+ *
+ * @return Vips\Image The manipulated image.
+ */
+function sigLAB(Vips\Image $image, bool $sharpen, float $midpoint, float $contrast): Vips\Image
 {
-    $old_interpretation = $image->interpretation;
+    $oldInterpretation = $image->interpretation;
 
-    # labs is CIELAB with colour values expressed as short (signed 16-bit ints)
-    # L is in 0 - 32767
+    /**
+     * Labs is CIELAB with colour values expressed as short (signed 16-bit ints)
+     * L is in 0 - 32767
+     */
     $image = $image->colourspace(Vips\Interpretation::LABS);
 
-    # make a 16-bit LUT, then shrink by x2 to make it fit the range of L in labs
-    $lut = sigmoid($alpha, $beta, true);
+    // Make a 16-bit LUT, then shrink by x2 to make it fit the range of L in labs
+    $lut = sigmoid($sharpen, $midpoint, $contrast, true);
     $lut = $lut->shrinkh(2)->multiply(0.5);
     $lut = $lut->cast(Vips\BandFormat::SHORT);
 
-    # get the L band from our labs image, map though the LUT, then reattach the
-    # ab bands from the labs image
+    /**
+     * Get the L band from our labs image, map though the LUT, then reattach the
+     * ab bands from the labs image
+     */
     $L = $image->extract_band(0);
     $AB = $image->extract_band(1, ['n' => 2]);
     $L = $L->maplut($lut);
     $image = $L->bandjoin($AB);
 
-    # and back to our original colourspace again (probably rgb)
-    #
-    # after the manipulation above, $image will just be tagged as a generic
-    # multiband image, vips will no longer know that it's a labs, so we need to
-    # tell colourspace what the source space is
-    $image = $image->colourspace(
-        $old_interpretation,
-        ['source_space' => Vips\Interpretation::LABS]
-    );
-
-    return $image;
+    /**
+     * And back to our original colourspace again (probably rgb)
+     *
+     * After the manipulation above, $image will just be tagged as a generic
+     * multiband image, vips will no longer know that it's a labs, so we need to
+     * tell colourspace what the source space is
+     */
+    return $image->colourspace($oldInterpretation, [
+        'source_space' => Vips\Interpretation::LABS
+    ]);
 }
 
 $im = Vips\Image::newFromFile($argv[1], ['access' => Vips\Access::SEQUENTIAL]);
 
-# $beta == 10 is a large contrast boost, values below about 4 drop the contrast
-#
-# sigLAB is the fancy one, and is much slower than sigRGB
-$im = sigLAB($im, 0.5, 7);
+/**
+ * $contrast == 10 is a large contrast boost, values below about 4 drop the contrast
+ *
+ * sigLAB is the fancy one, and is much slower than sigRGB
+ */
+$im = sigLAB($im, true, 0.5, 7);
 
 $im->writeToFile($argv[2]);
 

--- a/phpcs-ruleset.xml
+++ b/phpcs-ruleset.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<ruleset name="php-vips">
+    <!-- Set a description for this ruleset -->
+    <description>php-vips coding standard. Inherits from PSR-2.</description>
+
+    <!-- Check all files in this directory and the directories below it -->
+    <file>.</file>
+
+    <!-- Ignore Composer dependencies -->
+    <exclude-pattern>vendor/</exclude-pattern>
+
+    <!-- Display progress -->
+    <arg value="p"/>
+
+    <!-- Only check PHP files -->
+    <arg name="extensions" value="php"/>
+
+    <!-- Include the whole PSR-2 standard -->
+    <rule ref="PSR2"/>
+
+    <!-- Exclude this rule for code examples -->
+    <rule ref="PSR1.Files.SideEffects.FoundWithSymbols">
+        <exclude-pattern>examples/</exclude-pattern>
+    </rule>
+
+    <!-- File is generated automatically -->
+    <rule ref="Generic.Files.LineLength">
+        <exclude-pattern>src/ImageAutodoc.php</exclude-pattern>
+    </rule>
+</ruleset>

--- a/src/Image.php
+++ b/src/Image.php
@@ -1663,7 +1663,11 @@ class Image extends ImageAutodoc implements \ArrayAccess
     {
         /* Allow a single unarrayed value as well.
          */
-        $other = (array) $other;
+        if ($other instanceof Image) {
+            $other = [$other];
+        } else {
+            $other = (array) $other;
+        }
 
         /* If $other is all numbers, we can use self::bandjoin_const().
          */
@@ -1727,7 +1731,11 @@ class Image extends ImageAutodoc implements \ArrayAccess
 
         /* Allow a single unarrayed value as well.
          */
-        $other = (array) $other;
+        if ($other instanceof Image) {
+            $other = [$other];
+        } else {
+            $other = (array) $other;
+        }
 
         return self::call('bandrank', $this, $other, $options);
     }

--- a/tests/CallTest.php
+++ b/tests/CallTest.php
@@ -1,8 +1,11 @@
 <?php
 
-use Jcupitt\Vips;
+namespace Jcupitt\Vips\Test;
 
-class VipsCallTest extends PHPUnit\Framework\TestCase
+use Jcupitt\Vips;
+use PHPUnit\Framework\TestCase;
+
+class CallTest extends TestCase
 {
     public function testVipsCall()
     {
@@ -16,7 +19,7 @@ class VipsCallTest extends PHPUnit\Framework\TestCase
 
     public function testVipsCallStatic()
     {
-        $image = Vips\Image::black(1, 4, ["bands" => 3]);
+        $image = Vips\Image::black(1, 4, ['bands' => 3]);
 
         $this->assertEquals($image->width, 1);
         $this->assertEquals($image->height, 4);
@@ -45,7 +48,6 @@ class VipsCallTest extends PHPUnit\Framework\TestCase
         $this->assertEquals($image->getpoint(0, 0), [0]);
         $this->assertEquals($image->getpoint(50, 50), [255]);
     }
-
 }
 
 /*

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -1,8 +1,11 @@
 <?php
 
-use Jcupitt\Vips;
+namespace Jcupitt\Vips\Test;
 
-class VipsConfigTest extends PHPUnit\Framework\TestCase
+use Jcupitt\Vips;
+use PHPUnit\Framework\TestCase;
+
+class ConfigTest extends TestCase
 {
     public function testVipsCacheSetMax()
     {
@@ -25,7 +28,6 @@ class VipsConfigTest extends PHPUnit\Framework\TestCase
     {
         Vips\Config::concurrencySet(12);
     }
-
 }
 
 /*

--- a/tests/ConvenienceTest.php
+++ b/tests/ConvenienceTest.php
@@ -1,8 +1,11 @@
 <?php
 
-use Jcupitt\Vips;
+namespace Jcupitt\Vips\Test;
 
-class VipsConvenienceTest extends PHPUnit\Framework\TestCase
+use Jcupitt\Vips;
+use PHPUnit\Framework\TestCase;
+
+class ConvenienceTest extends TestCase
 {
     /**
      * @var Vips\Image
@@ -16,7 +19,7 @@ class VipsConvenienceTest extends PHPUnit\Framework\TestCase
 
     protected function setUp()
     {
-        $filename = dirname(__FILE__) . '/images/img_0076.jpg';
+        $filename = __DIR__ . '/images/img_0076.jpg';
         $this->image = Vips\Image::newFromFile($filename);
         $this->pixel = $this->image->getpoint(0, 0);
     }
@@ -35,7 +38,7 @@ class VipsConvenienceTest extends PHPUnit\Framework\TestCase
     {
         $arr = $this->image->bandsplit();
 
-        $this->assertEquals(count($arr), 3);
+        $this->assertCount(3, $arr);
         $this->assertEquals($arr[0]->bands, 1);
     }
 
@@ -54,7 +57,7 @@ class VipsConvenienceTest extends PHPUnit\Framework\TestCase
         $image = $image->subtract(1);
         $pixel = $image->getpoint(1, 1);
 
-        $this->assertEquals(count($pixel), 1);
+        $this->assertCount(1, $pixel);
         $this->assertEquals($pixel[0], 4);
     }
 
@@ -64,7 +67,7 @@ class VipsConvenienceTest extends PHPUnit\Framework\TestCase
         $image = $image->multiply(2);
         $pixel = $image->getpoint(1, 1);
 
-        $this->assertEquals(count($pixel), 1);
+        $this->assertCount(1, $pixel);
         $this->assertEquals($pixel[0], 10);
     }
 
@@ -74,7 +77,7 @@ class VipsConvenienceTest extends PHPUnit\Framework\TestCase
         $image = $image->divide(2);
         $pixel = $image->getpoint(0, 1);
 
-        $this->assertEquals(count($pixel), 1);
+        $this->assertCount(1, $pixel);
         $this->assertEquals($pixel[0], 2);
     }
 
@@ -144,7 +147,6 @@ class VipsConvenienceTest extends PHPUnit\Framework\TestCase
 
         $this->assertEquals($result, [37, 38, 33]);
     }
-
 }
 
 /*

--- a/tests/ExceptionTest.php
+++ b/tests/ExceptionTest.php
@@ -1,8 +1,11 @@
 <?php
 
-use Jcupitt\Vips;
+namespace Jcupitt\Vips\Test;
 
-class VipsExceptionTest extends PHPUnit\Framework\TestCase
+use Jcupitt\Vips;
+use PHPUnit\Framework\TestCase;
+
+class ExceptionTest extends TestCase
 {
     /**
      * @var Vips\Image
@@ -16,7 +19,7 @@ class VipsExceptionTest extends PHPUnit\Framework\TestCase
 
     protected function setUp()
     {
-        $filename = dirname(__FILE__) . '/images/img_0076.jpg';
+        $filename = __DIR__ . '/images/img_0076.jpg';
         $this->image = Vips\Image::newFromFile($filename);
         $this->pixel = $this->image->getpoint(0, 0);
     }
@@ -55,7 +58,6 @@ class VipsExceptionTest extends PHPUnit\Framework\TestCase
 
         $x = $this->image->add([1, 2, 3, 4]);
     }
-
 }
 
 /*

--- a/tests/LoggerTest.php
+++ b/tests/LoggerTest.php
@@ -1,8 +1,13 @@
 <?php
 
-use Jcupitt\Vips;
+namespace Jcupitt\Vips\Test;
 
-class VipsLoggerTest extends PHPUnit\Framework\TestCase
+use Jcupitt\Vips;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Psr\Log\LoggerTrait;
+
+class LoggerTest extends TestCase
 {
     public function testGetLoggerCall()
     {
@@ -15,9 +20,19 @@ class VipsLoggerTest extends PHPUnit\Framework\TestCase
 
     public function testSetLoggerCall()
     {
-        Vips\Config::setLogger(new class implements Psr\Log\LoggerInterface {
-            use Psr\Log\LoggerTrait;
+        Vips\Config::setLogger(new class implements LoggerInterface
+        {
+            use LoggerTrait;
 
+            /**
+             * Logs with an arbitrary level.
+             *
+             * @param mixed  $level
+             * @param string $message
+             * @param array  $context
+             *
+             * @return void
+             */
             public function log($level, $message, array $context = array())
             {
                 // Do logging logic here.
@@ -27,9 +42,8 @@ class VipsLoggerTest extends PHPUnit\Framework\TestCase
         $logger = Vips\Config::getLogger();
 
         // Asserts that getLogger should return an instance of Psr\Log\LoggerInterface
-        $this->assertInstanceOf(Psr\Log\LoggerInterface::class, $logger);
+        $this->assertInstanceOf(LoggerInterface::class, $logger);
     }
-
 }
 
 /*

--- a/tests/MetaTest.php
+++ b/tests/MetaTest.php
@@ -1,8 +1,11 @@
 <?php
 
-use Jcupitt\Vips;
+namespace Jcupitt\Vips\Test;
 
-class VipsMetaTest extends PHPUnit\Framework\TestCase
+use Jcupitt\Vips;
+use PHPUnit\Framework\TestCase;
+
+class MetaTest extends TestCase
 {
     /**
      * @var Vips\Image
@@ -16,10 +19,10 @@ class VipsMetaTest extends PHPUnit\Framework\TestCase
 
     protected function setUp()
     {
-        $filename = dirname(__FILE__) . '/images/img_0076.jpg';
+        $filename = __DIR__ . '/images/img_0076.jpg';
         $this->image = Vips\Image::newFromFile($filename);
 
-        $png_filename = dirname(__FILE__) . '/images/PNG_transparency_demonstration_1.png';
+        $png_filename = __DIR__ . '/images/PNG_transparency_demonstration_1.png';
         $this->png_image = Vips\Image::newFromFile($png_filename);
     }
 
@@ -76,10 +79,9 @@ class VipsMetaTest extends PHPUnit\Framework\TestCase
 
     public function testVipsHasAlpha()
     {
-        $this->assertEquals($this->image->hasAlpha(), FALSE);
-        $this->assertEquals($this->png_image->hasAlpha(), TRUE);
+        $this->assertEquals($this->image->hasAlpha(), false);
+        $this->assertEquals($this->png_image->hasAlpha(), true);
     }
-
 }
 
 /*

--- a/tests/NewTest.php
+++ b/tests/NewTest.php
@@ -1,8 +1,11 @@
 <?php
 
-use Jcupitt\Vips;
+namespace Jcupitt\Vips\Test;
 
-class VipsNewTest extends PHPUnit\Framework\TestCase
+use Jcupitt\Vips;
+use PHPUnit\Framework\TestCase;
+
+class NewTest extends TestCase
 {
 
     public function testVipsNewFromArray()
@@ -23,7 +26,7 @@ class VipsNewTest extends PHPUnit\Framework\TestCase
 
     public function testVipsNewFromFile()
     {
-        $filename = dirname(__FILE__) . '/images/img_0076.jpg';
+        $filename = __DIR__ . '/images/img_0076.jpg';
         $image = Vips\Image::newFromFile($filename);
 
         $this->assertEquals($image->width, 1600);
@@ -33,7 +36,7 @@ class VipsNewTest extends PHPUnit\Framework\TestCase
 
     public function testVipsNewFromImage()
     {
-        $filename = dirname(__FILE__) . '/images/img_0076.jpg';
+        $filename = __DIR__ . '/images/img_0076.jpg';
         $image = Vips\Image::newFromFile($filename);
 
         $image2 = $image->newFromImage(12);
@@ -48,7 +51,7 @@ class VipsNewTest extends PHPUnit\Framework\TestCase
         $this->assertEquals($image2->bands, 1);
         $this->assertEquals($image2->avg(), 12);
 
-        $image2 = $image->newFromImage([1,2,3]);
+        $image2 = $image->newFromImage([1, 2, 3]);
 
         $this->assertEquals($image2->bands, 3);
         $this->assertEquals($image2->avg(), 2);
@@ -56,7 +59,7 @@ class VipsNewTest extends PHPUnit\Framework\TestCase
 
     public function testVipsFindLoad()
     {
-        $filename = dirname(__FILE__) . '/images/img_0076.jpg';
+        $filename = __DIR__ . '/images/img_0076.jpg';
         $loader = Vips\Image::findLoad($filename);
 
         $this->assertEquals($loader, 'VipsForeignLoadJpegFile');
@@ -64,7 +67,7 @@ class VipsNewTest extends PHPUnit\Framework\TestCase
 
     public function testVipsNewFromBuffer()
     {
-        $filename = dirname(__FILE__) . '/images/img_0076.jpg';
+        $filename = __DIR__ . '/images/img_0076.jpg';
         $buffer = file_get_contents($filename);
         $image = Vips\Image::newFromBuffer($buffer);
 
@@ -75,7 +78,7 @@ class VipsNewTest extends PHPUnit\Framework\TestCase
 
     public function testVipsFindLoadBuffer()
     {
-        $filename = dirname(__FILE__) . '/images/img_0076.jpg';
+        $filename = __DIR__ . '/images/img_0076.jpg';
         $buffer = file_get_contents($filename);
         $loader = Vips\Image::findLoadBuffer($buffer);
 
@@ -84,7 +87,7 @@ class VipsNewTest extends PHPUnit\Framework\TestCase
 
     public function testVipsCopyMemory()
     {
-        $filename = dirname(__FILE__) . '/images/img_0076.jpg';
+        $filename = __DIR__ . '/images/img_0076.jpg';
         $image1 = Vips\Image::newFromFile($filename);
         $image2 = $image1->copyMemory();
 
@@ -93,7 +96,7 @@ class VipsNewTest extends PHPUnit\Framework\TestCase
 
     public function testVipsNewInterpolator()
     {
-        $filename = dirname(__FILE__) . '/images/img_0076.jpg';
+        $filename = __DIR__ . '/images/img_0076.jpg';
         $image1 = Vips\Image::newFromFile($filename);
         $interp = Vips\Image::newInterpolator('bicubic');
         $image2 = $image1->affine([2, 0, 0, 2], ['interpolate' => $interp]);
@@ -104,7 +107,6 @@ class VipsNewTest extends PHPUnit\Framework\TestCase
         $this->assertNotNull($interp);
         $this->assertEquals($widthInput * 2, $widthOutput);
     }
-
 }
 
 /*

--- a/tests/ShortcutTest.php
+++ b/tests/ShortcutTest.php
@@ -130,8 +130,8 @@ class ShortcutTest extends TestCase
         $this->assertEquals($vips, $real);
 
         $real = self::mapNumeric($this->pixel, function ($value) {
-            // FIXME: Left and right operands are identical
-            return $value > $value ? 255 : 0;
+            // $value > $value is always false
+            return 0;
         });
         $vips = $this->image->more($this->image)->getpoint(0, 0);
         $this->assertEquals($vips, $real);

--- a/tests/ShortcutTest.php
+++ b/tests/ShortcutTest.php
@@ -1,8 +1,11 @@
 <?php
 
-use Jcupitt\Vips;
+namespace Jcupitt\Vips\Test;
 
-class VipsShortcutTest extends PHPUnit\Framework\TestCase
+use Jcupitt\Vips;
+use PHPUnit\Framework\TestCase;
+
+class ShortcutTest extends TestCase
 {
     /**
      * @var Vips\Image
@@ -14,31 +17,30 @@ class VipsShortcutTest extends PHPUnit\Framework\TestCase
      */
     private $pixel;
 
-    static function map_numeric($value, $func)
+    public static function mapNumeric($value, $func)
     {
         if (is_numeric($value)) {
             $value = $func($value);
-        }
-        else if (is_array($value)) {
+        } elseif (is_array($value)) {
             array_walk_recursive($value, function (&$item, $key) use ($func) {
-                $item = self::map_numeric($item, $func);
+                $item = self::mapNumeric($item, $func);
             });
         }
 
         return $value;
-    } 
+    }
 
     protected function setUp()
     {
-        $filename = dirname(__FILE__) . '/images/img_0076.jpg';
+        $filename = __DIR__ . '/images/img_0076.jpg';
         $this->image = Vips\Image::newFromFile($filename, ['shrink' => 8]);
         $this->pixel = $this->image->getpoint(0, 0);
     }
 
     public function testVipsPow()
     {
-        $real = self::map_numeric($this->pixel, function ($value) {
-            return $value ** 2; 
+        $real = self::mapNumeric($this->pixel, function ($value) {
+            return $value ** 2;
         });
         $vips = $this->image->pow(2)->getpoint(0, 0);
 
@@ -47,8 +49,8 @@ class VipsShortcutTest extends PHPUnit\Framework\TestCase
 
     public function testVipsWop()
     {
-        $real = self::map_numeric($this->pixel, function ($value) {
-            return 2 ** $value; 
+        $real = self::mapNumeric($this->pixel, function ($value) {
+            return 2 ** $value;
         });
         $vips = $this->image->wop(2)->getpoint(0, 0);
 
@@ -57,144 +59,106 @@ class VipsShortcutTest extends PHPUnit\Framework\TestCase
 
     public function testVipsRemainder()
     {
-        $real = self::map_numeric($this->pixel, function ($value) {
-            return $value % 2; 
+        $real = self::mapNumeric($this->pixel, function ($value) {
+            return $value % 2;
         });
         $vips = $this->image->remainder(2)->getpoint(0, 0);
 
         $this->assertEquals($vips, $real);
 
-        $real = self::map_numeric($this->pixel, function ($value) {
-            return $value % $value; 
+        $real = self::mapNumeric($this->pixel, function ($value) {
+            return $value % $value;
         });
         $vips = $this->image->remainder($this->image)->getpoint(0, 0);
 
         $this->assertEquals($vips, $real);
-
     }
 
     public function testVipsShift()
     {
-        $real = self::map_numeric($this->pixel, function ($value) {
-            return $value << 2; 
+        $real = self::mapNumeric($this->pixel, function ($value) {
+            return $value << 2;
         });
         $vips = $this->image->lshift(2)->getpoint(0, 0);
 
         $this->assertEquals($vips, $real);
 
-        $real = self::map_numeric($this->pixel, function ($value) {
-            return $value >> 2; 
+        $real = self::mapNumeric($this->pixel, function ($value) {
+            return $value >> 2;
         });
         $vips = $this->image->rshift(2)->getpoint(0, 0);
 
         $this->assertEquals($vips, $real);
-
     }
 
     public function testVipsBool()
     {
-        $real = self::map_numeric($this->pixel, function ($value) {
-            return $value & 2; 
+        $real = self::mapNumeric($this->pixel, function ($value) {
+            return $value & 2;
         });
         $vips = $this->image->andimage(2)->getpoint(0, 0);
 
         $this->assertEquals($vips, $real);
 
-        $real = self::map_numeric($this->pixel, function ($value) {
-            return $value | 2; 
+        $real = self::mapNumeric($this->pixel, function ($value) {
+            return $value | 2;
         });
         $vips = $this->image->orimage(2)->getpoint(0, 0);
 
         $this->assertEquals($vips, $real);
 
-        $real = self::map_numeric($this->pixel, function ($value) {
-            return $value ^ 2; 
+        $real = self::mapNumeric($this->pixel, function ($value) {
+            return $value ^ 2;
         });
         $vips = $this->image->eorimage(2)->getpoint(0, 0);
 
         $this->assertEquals($vips, $real);
-
     }
 
     public function testVipsRelational()
     {
-        $real = self::map_numeric($this->pixel, function ($value) {
-            if ($value > 38) {
-                return 255;
-            }
-            else {
-                return 0;
-            }
+        $real = self::mapNumeric($this->pixel, function ($value) {
+            return $value > 38 ? 255 : 0;
         });
         $vips = $this->image->more(38)->getpoint(0, 0);
         $this->assertEquals($vips, $real);
 
-        $real = self::map_numeric($this->pixel, function ($value) {
-            if ($value >= 38) {
-                return 255;
-            }
-            else {
-                return 0;
-            }
+        $real = self::mapNumeric($this->pixel, function ($value) {
+            return $value >= 38 ? 255 : 0;
         });
-        $vips = $this->image->moreeq(38)->getpoint(0, 0);
+        $vips = $this->image->moreEq(38)->getpoint(0, 0);
         $this->assertEquals($vips, $real);
 
-        $real = self::map_numeric($this->pixel, function ($value) {
-            if ($value > $value) {
-                return 255;
-            }
-            else {
-                return 0;
-            }
+        $real = self::mapNumeric($this->pixel, function ($value) {
+            // FIXME: Left and right operands are identical
+            return $value > $value ? 255 : 0;
         });
         $vips = $this->image->more($this->image)->getpoint(0, 0);
         $this->assertEquals($vips, $real);
 
-        $real = self::map_numeric($this->pixel, function ($value) {
-            if ($value < 38) {
-                return 255;
-            }
-            else {
-                return 0;
-            }
+        $real = self::mapNumeric($this->pixel, function ($value) {
+            return $value < 38 ? 255 : 0;
         });
         $vips = $this->image->less(38)->getpoint(0, 0);
         $this->assertEquals($vips, $real);
 
-        $real = self::map_numeric($this->pixel, function ($value) {
-            if ($value <= 38) {
-                return 255;
-            }
-            else {
-                return 0;
-            }
+        $real = self::mapNumeric($this->pixel, function ($value) {
+            return $value <= 38 ? 255 : 0;
         });
-        $vips = $this->image->lesseq(38)->getpoint(0, 0);
+        $vips = $this->image->lessEq(38)->getpoint(0, 0);
         $this->assertEquals($vips, $real);
 
-        $real = self::map_numeric($this->pixel, function ($value) {
-            if ($value == 38) {
-                return 255;
-            }
-            else {
-                return 0;
-            }
+        $real = self::mapNumeric($this->pixel, function ($value) {
+            return $value === 38 ? 255 : 0;
         });
         $vips = $this->image->equal(38)->getpoint(0, 0);
         $this->assertEquals($vips, $real);
 
-        $real = self::map_numeric($this->pixel, function ($value) {
-            if ($value != 38) {
-                return 255;
-            }
-            else {
-                return 0;
-            }
+        $real = self::mapNumeric($this->pixel, function ($value) {
+            return $value !== 38 ? 255 : 0;
         });
-        $vips = $this->image->noteq(38)->getpoint(0, 0);
+        $vips = $this->image->notEq(38)->getpoint(0, 0);
         $this->assertEquals($vips, $real);
-
     }
 
     public function testVipsRound()
@@ -202,31 +166,30 @@ class VipsShortcutTest extends PHPUnit\Framework\TestCase
         $image = $this->image->add([0.1, 1.4, 0.9]);
         $pixel = $image->getpoint(0, 0);
 
-        $real = self::map_numeric($pixel, function ($value) {
+        $real = self::mapNumeric($pixel, function ($value) {
             return floor($value);
         });
         $vips = $image->floor()->getpoint(0, 0);
         $this->assertEquals($vips, $real);
 
-        $real = self::map_numeric($pixel, function ($value) {
+        $real = self::mapNumeric($pixel, function ($value) {
             return ceil($value);
         });
         $vips = $image->ceil()->getpoint(0, 0);
         $this->assertEquals($vips, $real);
 
-        $real = self::map_numeric($pixel, function ($value) {
+        $real = self::mapNumeric($pixel, function ($value) {
             return round($value);
         });
         $vips = $image->rint()->getpoint(0, 0);
         $this->assertEquals($vips, $real);
-
     }
 
     public function testVipsBandand()
     {
         $real = $this->pixel[0] & $this->pixel[1] & $this->pixel[2];
         $vips = $this->image->bandand()->getpoint(0, 0);
-        $this->assertEquals(count($vips), 1);
+        $this->assertCount(1, $vips);
         $this->assertEquals($vips[0], $real);
     }
 
@@ -283,7 +246,6 @@ class VipsShortcutTest extends PHPUnit\Framework\TestCase
         $this->assertEquals($test[1]->avg(), 3);
         $this->assertEquals($test[2]->avg(), 4);
         $this->assertEquals($test[3]->avg(), 12);
-
     }
 
     public function testOffsetUnset()
@@ -319,7 +281,6 @@ class VipsShortcutTest extends PHPUnit\Framework\TestCase
         $this->assertEquals($test[0]->avg(), 2);
         $this->assertEquals($test[1]->avg(), 3);
         $this->assertEquals($test[2]->avg(), 4);
-
     }
 
     public function testOffsetUnsetAll()
@@ -328,7 +289,7 @@ class VipsShortcutTest extends PHPUnit\Framework\TestCase
 
         // remove all
         $test = $base->copy();
-        $this->expectException(BadMethodCallException::class);
+        $this->expectException(\BadMethodCallException::class);
         unset($test[0]);
     }
 }

--- a/tests/WriteTest.php
+++ b/tests/WriteTest.php
@@ -1,27 +1,30 @@
 <?php
 
-use Jcupitt\Vips;
+namespace Jcupitt\Vips\Test;
 
-class VipsWriteTest extends PHPUnit\Framework\TestCase
+use Jcupitt\Vips;
+use PHPUnit\Framework\TestCase;
+
+class WriteTest extends TestCase
 {
     /**
      * @var array
      */
     private $tmps;
 
-    function setUp()
+    protected function setUp()
     {
         $this->tmps = [];
     }
 
-    function tearDown()
+    protected function tearDown()
     {
         foreach ($this->tmps as $tmp) {
-          @unlink($tmp);
+            @unlink($tmp);
         }
     }
 
-    function tmp($suffix)
+    public function tmp($suffix)
     {
         $tmp = tempnam(sys_get_temp_dir(), 'vips-test');
         unlink($tmp);
@@ -33,7 +36,7 @@ class VipsWriteTest extends PHPUnit\Framework\TestCase
 
     public function testVipsWriteToFile()
     {
-        $filename = dirname(__FILE__) . '/images/img_0076.jpg';
+        $filename = __DIR__ . '/images/img_0076.jpg';
         $image = Vips\Image::newFromFile($filename, ['shrink' => 8]);
         $output_filename = $this->tmp('.jpg');
         $image->writeToFile($output_filename);
@@ -46,7 +49,7 @@ class VipsWriteTest extends PHPUnit\Framework\TestCase
 
     public function testVipsWriteToBuffer()
     {
-        $filename = dirname(__FILE__) . '/images/img_0076.jpg';
+        $filename = __DIR__ . '/images/img_0076.jpg';
         $image = Vips\Image::newFromFile($filename, ['shrink' => 8]);
 
         $buffer1 = $image->writeToBuffer('.jpg');
@@ -54,9 +57,8 @@ class VipsWriteTest extends PHPUnit\Framework\TestCase
         $image->writeToFile($output_filename);
         $buffer2 = file_get_contents($output_filename);
 
-        $this->assertEquals($buffer1, $buffer2); 
+        $this->assertEquals($buffer1, $buffer2);
     }
-
 }
 
 /*


### PR DESCRIPTION
- Fix PSR-2 errors from phpcs.
- Update phpunit.
- Update sigmoidal contrast example.
- Fix regression from #49 (`bandjoin`/`bandrank` a `Image` class didn't work).
- Rename the test files and apply the correct namespace.