### PR TITLE
Fix blendmode + add missing @throws declarations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ php:
 env:
   global:
     - VIPS_VERSION_MAJOR=8
-    - VIPS_VERSION_MINOR=5
-    - VIPS_VERSION_MICRO=8
+    - VIPS_VERSION_MINOR=6
+    - VIPS_VERSION_MICRO=0
     - PATH=$HOME/vips/bin:$PATH
     - LD_LIBRARY_PATH=$HOME/vips/lib:$LD_LIBRARY_PATH
     - PKG_CONFIG_PATH=$HOME/vips/lib/pkgconfig:$PKG_CONFIG_PATH

--- a/src/Config.php
+++ b/src/Config.php
@@ -146,7 +146,7 @@ class Config
      *
      * @return string
      */
-    public static function version()
+    public static function version(): string
     {
         return vips_version();
     }


### PR DESCRIPTION
- The string to int conversion for blend modes was removed by f016fd5be8923482b9b55e84e21259688c376a29 (due to auto generated code) so I re-added it to the Image class.
- I've checked the `@throws` declarations with my IDE and found a few that were missing.
- Now that libvips 8.6 is released (:tada:), I've updated Travis libvips to 8.6.

PR is on `add-throws-decls`, I can switch to master if you want.